### PR TITLE
add current repo to safe.directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -l
 
+git config --global --add safe.directory `pwd`
 git reset --hard HEAD
 branch_name="lean-$(grep -oP 'lean_version = [\s\S]*lean\:\K[\d.]+(?=\")' leanpkg.toml)"
 


### PR DESCRIPTION
This is necessary for security reasons since Git 2.35.2, because the original checkout is performed outside the Docker container (with a different user). See https://leanprover.zulipchat.com/#narrow/stream/113538-CI/topic/CI.20for.203rd.20party.20project